### PR TITLE
fix:  fixed setup_env.py to run normally. 

### DIFF
--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -29,7 +29,7 @@ commands = [
     [sys.executable, "-m", "pip", "install", "--no-cache-dir", "-U", "langchain-community"],
     [sys.executable, "-m", "pip", "install", "--no-cache-dir", "--force-reinstall", "torch==2.3.1", "torchvision==0.18.1", "numpy<2.0.0", "--index-url", "https://download.pytorch.org/whl/cu118"],
     [sys.executable, "-m", "pip", "install", "--no-cache-dir", "-U", "magic-pdf[full]", "--extra-index-url", "https://wheels.myhloli.com"],
-    [sys.executable, "-m", "pip", "install", "--no-cache-dir", "Django==2.2.5"]
+    [sys.executable, "-m", "pip", "install", "--no-cache-dir", "Django==2.2.5"],
     [sys.executable, "-m", "pip", "install", "--no-cache-dir", "graphviz"]
 ]
 


### PR DESCRIPTION
Added a comma to the end of line 32.

When trying to run "python scripts/setup_env.py" I got this error:

" /home/breno/Documentos/InteractiveSurvey/scripts/setup_env.py:32: SyntaxWarning: list indices must be integers or slices, not tuple; perhaps you missed a comma?
  [sys.executable, "-m", "pip", "install", "--no-cache-dir", "Django==2.2.5"]
Traceback (most recent call last):
  File "/home/breno/Documentos/InteractiveSurvey/scripts/setup_env.py", line 32, in <module>
    [sys.executable, "-m", "pip", "install", "--no-cache-dir", "Django==2.2.5"]
TypeError: list indices must be integers or slices, not tuple."

Adding this comma fixed this issue